### PR TITLE
Frontend refinements: filing status tabs, chart styling, and reform tests

### DIFF
--- a/frontend/components/PolicyOverview.tsx
+++ b/frontend/components/PolicyOverview.tsx
@@ -16,9 +16,9 @@ import {
 } from 'recharts';
 
 const FILING_STATUSES = [
-  { key: 'single', label: 'Single', current: 16_100, proposed: 37_500, color: '#2563eb' },
-  { key: 'hoh', label: 'Head of household', current: 24_150, proposed: 56_250, color: '#059669' },
-  { key: 'joint', label: 'Married filing jointly', current: 32_200, proposed: 75_000, color: '#7c3aed' },
+  { key: 'single', label: 'Single', current: 16_100, proposed: 37_500, color: '#319795' },
+  { key: 'hoh', label: 'Head of household', current: 24_150, proposed: 56_250, color: '#285E61' },
+  { key: 'joint', label: 'Married filing jointly', current: 32_200, proposed: 75_000, color: '#1D4044' },
 ];
 
 function formatDollarFull(value: number): string {
@@ -52,6 +52,9 @@ export default function PolicyOverview() {
     }
     return points;
   }, []);
+
+  // Selected filing status for taxable income chart
+  const [selectedFs, setSelectedFs] = useState(0);
 
   // CTC by income data loaded from CSV
   const [ctcByIncomeData, setCtcByIncomeData] = useState<Array<{
@@ -170,6 +173,78 @@ export default function PolicyOverview() {
         </div>
       </div>
 
+      {/* Taxable income comparison chart — tabbed by filing status */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+          Taxable income by AGI (2026)
+        </h3>
+
+        {/* Tab buttons */}
+        <div className="flex gap-1 mb-3">
+          {FILING_STATUSES.map((f, i) => (
+            <button
+              key={f.key}
+              onClick={() => setSelectedFs(i)}
+              className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                selectedFs === i
+                  ? 'text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+              style={selectedFs === i ? { backgroundColor: f.color } : undefined}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={taxableIncomeData}
+              margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="agi" tickFormatter={formatDollar} type="number" allowDecimals={false} />
+              <YAxis tickFormatter={formatDollar} allowDecimals={false} domain={[0, 100000]} type="number" ticks={[0, 25000, 50000, 75000, 100000]} />
+              <Tooltip
+                formatter={(value: number) => formatDollarFull(value)}
+                labelFormatter={(label: number) => `AGI: ${formatDollarFull(label)}`}
+              />
+              <Legend />
+              <ReferenceLine
+                x={FILING_STATUSES[selectedFs].current}
+                stroke="#9CA3AF"
+                strokeDasharray="3 3"
+                label={{ value: `Current SD: ${formatDollarFull(FILING_STATUSES[selectedFs].current)}`, position: 'insideTopRight', fill: '#6b7280', fontSize: 11 }}
+              />
+              <ReferenceLine
+                x={FILING_STATUSES[selectedFs].proposed}
+                stroke={FILING_STATUSES[selectedFs].color}
+                strokeDasharray="3 3"
+                label={{ value: `Proposed SD: ${formatDollarFull(FILING_STATUSES[selectedFs].proposed)}`, position: 'insideTopLeft', fill: FILING_STATUSES[selectedFs].color, fontSize: 11 }}
+              />
+              <Line
+                type="monotone"
+                dataKey={`${FILING_STATUSES[selectedFs].key}_current`}
+                name="Current law"
+                stroke="#9CA3AF"
+                strokeWidth={2}
+                strokeDasharray="5 5"
+                dot={false}
+              />
+              <Line
+                type="monotone"
+                dataKey={`${FILING_STATUSES[selectedFs].key}_proposed`}
+                name="Keep Your Pay Act"
+                stroke={FILING_STATUSES[selectedFs].color}
+                strokeWidth={2}
+                dot={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
       {/* CTC by income line chart */}
       <div>
         <h3 className="text-lg font-semibold text-gray-900 mb-3">
@@ -187,6 +262,7 @@ export default function PolicyOverview() {
                 tickFormatter={formatDollar}
                 type="number"
                 domain={[0, 350000]}
+                ticks={[0, 100000, 200000, 300000]}
                 tick={{ fontSize: 12 }}
               />
               <YAxis tickFormatter={formatDollar} tick={{ fontSize: 12 }} />
@@ -235,106 +311,10 @@ export default function PolicyOverview() {
         </p>
       </div>
 
-      {/* Taxable income comparison chart */}
+      {/* EITC comparison (childless workers) (2026) */}
       <div>
         <h3 className="text-lg font-semibold text-gray-900 mb-3">
-          Taxable income by AGI: single filer
-        </h3>
-        <div className="h-80">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart
-              data={taxableIncomeData}
-              margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="agi" tickFormatter={formatDollar} type="number" allowDecimals={false} />
-              <YAxis tickFormatter={formatDollar} allowDecimals={false} />
-              <Tooltip
-                formatter={(value: number) => formatDollarFull(value)}
-                labelFormatter={(label: number) => `AGI: ${formatDollarFull(label)}`}
-              />
-              <Legend />
-              <ReferenceLine
-                x={16100}
-                stroke="#9CA3AF"
-                strokeDasharray="3 3"
-                label={{ value: 'Current zero-tax: $16,100', position: 'insideTopRight', fill: '#6b7280', fontSize: 11 }}
-              />
-              <ReferenceLine
-                x={37500}
-                stroke="#319795"
-                strokeDasharray="3 3"
-                label={{ value: 'Proposed zero-tax: $37,500', position: 'insideTopLeft', fill: '#319795', fontSize: 11 }}
-              />
-              <Line
-                type="monotone"
-                dataKey="single_current"
-                name="Current law"
-                stroke="#9CA3AF"
-                strokeWidth={2}
-                strokeDasharray="5 5"
-                dot={false}
-              />
-              <Line
-                type="monotone"
-                dataKey="single_proposed"
-                name="Keep Your Pay Act"
-                stroke="#319795"
-                strokeWidth={2}
-                dot={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        <p className="text-xs text-gray-500 mt-2">
-          Under the Keep Your Pay Act, a single filer would owe zero federal income tax
-          on the first $37,500 of AGI, compared to $16,100 under current law.
-        </p>
-      </div>
-
-      {/* Child Tax Credit comparison */}
-      <div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-3">
-          Child Tax Credit comparison
-        </h3>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm border-collapse">
-            <thead>
-              <tr className="bg-gray-100">
-                <th className="text-left p-3 border">Category</th>
-                <th className="text-right p-3 border">Current law</th>
-                <th className="text-right p-3 border">Keep Your Pay Act</th>
-                <th className="text-right p-3 border">Change</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td className="p-3 border font-medium">Child under 6</td>
-                <td className="p-3 border text-right">$2,200</td>
-                <td className="p-3 border text-right font-semibold">$4,320</td>
-                <td className="p-3 border text-right text-primary-700">+$2,120</td>
-              </tr>
-              <tr>
-                <td className="p-3 border font-medium">Child aged 6–17</td>
-                <td className="p-3 border text-right">$2,200</td>
-                <td className="p-3 border text-right font-semibold">$3,600</td>
-                <td className="p-3 border text-right text-primary-700">+$1,400</td>
-              </tr>
-              <tr>
-                <td className="p-3 border font-medium">Baby bonus (year of birth)</td>
-                <td className="p-3 border text-right">—</td>
-                <td className="p-3 border text-right font-semibold">$2,400</td>
-                <td className="p-3 border text-right text-primary-700">+$2,400</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      {/* EITC comparison (childless workers) */}
-      <div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-3">
-          EITC comparison (childless workers)
+          EITC for childless workers comparison (2026)
         </h3>
         <div className="overflow-x-auto">
           <table className="w-full text-sm border-collapse">

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for Keep Your Pay Act calculator

--- a/tests/test_reforms.py
+++ b/tests/test_reforms.py
@@ -1,0 +1,275 @@
+"""Tests for Keep Your Pay Act reform behavior.
+
+Verifies that the reform correctly applies:
+1. Standard deduction increases
+2. CTC expansion (AFA-style)
+3. EITC expansion for childless workers
+"""
+
+import pytest
+from policyengine_us import Simulation
+from kypa_calc.reforms import create_reform
+
+
+YEAR = 2026
+
+
+def build_single_person_situation(age: int, employment_income: int, year: int = 2026) -> dict:
+    """Build a single person situation for testing."""
+    return {
+        "people": {
+            "person": {
+                "age": {year: age},
+                "employment_income": {year: employment_income},
+            }
+        },
+        "families": {"family": {"members": ["person"]}},
+        "marital_units": {"marital_unit": {"members": ["person"]}},
+        "spm_units": {"spm_unit": {"members": ["person"]}},
+        "tax_units": {"tax_unit": {"members": ["person"]}},
+        "households": {
+            "household": {
+                "members": ["person"],
+                "state_code": {year: "CA"},
+            }
+        },
+    }
+
+
+def build_single_parent_situation(
+    parent_age: int, child_age: int, employment_income: int, year: int = 2026
+) -> dict:
+    """Build a single parent with one child situation."""
+    return {
+        "people": {
+            "parent": {
+                "age": {year: parent_age},
+                "employment_income": {year: employment_income},
+            },
+            "child": {
+                "age": {year: child_age},
+            },
+        },
+        "families": {"family": {"members": ["parent", "child"]}},
+        "marital_units": {
+            "parent_marital_unit": {"members": ["parent"]},
+            "child_marital_unit": {"members": ["child"]},
+        },
+        "spm_units": {"spm_unit": {"members": ["parent", "child"]}},
+        "tax_units": {"tax_unit": {"members": ["parent", "child"]}},
+        "households": {
+            "household": {
+                "members": ["parent", "child"],
+                "state_code": {year: "CA"},
+            }
+        },
+    }
+
+
+def build_married_couple_situation(employment_income: int, year: int = 2026) -> dict:
+    """Build a married couple situation."""
+    return {
+        "people": {
+            "spouse1": {
+                "age": {year: 35},
+                "employment_income": {year: employment_income},
+            },
+            "spouse2": {
+                "age": {year: 35},
+            },
+        },
+        "families": {"family": {"members": ["spouse1", "spouse2"]}},
+        "marital_units": {"marital_unit": {"members": ["spouse1", "spouse2"]}},
+        "spm_units": {"spm_unit": {"members": ["spouse1", "spouse2"]}},
+        "tax_units": {
+            "tax_unit": {
+                "members": ["spouse1", "spouse2"],
+                "tax_unit_is_joint": {year: True},
+            }
+        },
+        "households": {
+            "household": {
+                "members": ["spouse1", "spouse2"],
+                "state_code": {year: "CA"},
+            }
+        },
+    }
+
+
+class TestStandardDeduction:
+    """Test standard deduction increases under the reform."""
+
+    def test_single_standard_deduction_baseline(self):
+        """Baseline single filer should have ~$16,100 standard deduction."""
+        situation = build_single_person_situation(age=30, employment_income=50000)
+        sim = Simulation(situation=situation)
+        std_ded = sim.calculate("standard_deduction", period=YEAR)[0]
+        # Current law is around $16,100 for 2026
+        assert 15000 < std_ded < 17000
+
+    def test_single_standard_deduction_reform(self):
+        """Reform single filer should have $37,500 standard deduction."""
+        situation = build_single_person_situation(age=30, employment_income=50000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        std_ded = sim.calculate("standard_deduction", period=YEAR)[0]
+        assert std_ded == 37500
+
+    def test_joint_standard_deduction_baseline(self):
+        """Baseline joint filer should have ~$32,200 standard deduction."""
+        situation = build_married_couple_situation(employment_income=100000)
+        sim = Simulation(situation=situation)
+        std_ded = sim.calculate("standard_deduction", period=YEAR)[0]
+        # Current law is around $32,200 for 2026
+        assert 30000 < std_ded < 34000
+
+    def test_joint_standard_deduction_reform(self):
+        """Reform joint filer should have $75,000 standard deduction."""
+        situation = build_married_couple_situation(employment_income=100000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        std_ded = sim.calculate("standard_deduction", period=YEAR)[0]
+        assert std_ded == 75000
+
+
+class TestCTC:
+    """Test Child Tax Credit expansion under the reform."""
+
+    def test_ctc_child_under_6_reform(self):
+        """Reform CTC for child under 6 should be $4,320 (base $3,600 + $720 young child bonus)."""
+        situation = build_single_parent_situation(
+            parent_age=30, child_age=3, employment_income=50000
+        )
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        ctc = sim.calculate("ctc", period=YEAR)[0]
+        # AFA: $3,600 base + $720 young child bonus = $4,320
+        assert ctc == pytest.approx(4320, abs=100)
+
+    def test_ctc_child_6_to_17_reform(self):
+        """Reform CTC for child 6-17 should be $3,600."""
+        situation = build_single_parent_situation(
+            parent_age=30, child_age=10, employment_income=50000
+        )
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        ctc = sim.calculate("ctc", period=YEAR)[0]
+        assert ctc == pytest.approx(3600, abs=100)
+
+    def test_ctc_newborn_reform(self):
+        """Reform CTC for newborn should include baby bonus ($6,360 total)."""
+        situation = build_single_parent_situation(
+            parent_age=30, child_age=0, employment_income=50000
+        )
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        ctc = sim.calculate("ctc", period=YEAR)[0]
+        # Baby bonus: $2,400 for birth month + $360/month * 11 = $6,360
+        assert ctc == pytest.approx(6360, abs=200)
+
+    def test_ctc_fully_refundable_at_zero_income(self):
+        """Reform CTC should be fully refundable even at $0 income."""
+        situation = build_single_parent_situation(
+            parent_age=30, child_age=10, employment_income=0
+        )
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        ctc_value = sim.calculate("ctc_value", period=YEAR)[0]
+        # Should receive full credit even with no income
+        assert ctc_value == pytest.approx(3600, abs=100)
+
+
+class TestEITC:
+    """Test EITC expansion for childless workers."""
+
+    def test_eitc_max_credit_baseline(self):
+        """Baseline max EITC for childless worker should be ~$664."""
+        # Income at plateau for max EITC
+        situation = build_single_person_situation(age=30, employment_income=9000)
+        sim = Simulation(situation=situation)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        # Current law max is around $664
+        assert eitc < 800
+
+    def test_eitc_max_credit_reform(self):
+        """Reform max EITC for childless worker should be $1,502."""
+        # Income at plateau for max EITC (~$9,800 at 15.3% phase-in)
+        situation = build_single_person_situation(age=30, employment_income=10000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        assert eitc == pytest.approx(1502, abs=50)
+
+    def test_eitc_age_19_eligible_reform(self):
+        """19-year-old should be eligible for EITC under reform."""
+        situation = build_single_person_situation(age=19, employment_income=10000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        assert eitc > 0
+
+    def test_eitc_age_19_not_eligible_baseline(self):
+        """19-year-old should NOT be eligible for EITC under baseline."""
+        situation = build_single_person_situation(age=19, employment_income=10000)
+        sim = Simulation(situation=situation)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        assert eitc == 0
+
+    def test_eitc_age_70_eligible_reform(self):
+        """70-year-old should be eligible for EITC under reform (no max age)."""
+        situation = build_single_person_situation(age=70, employment_income=10000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        assert eitc > 0
+
+    def test_eitc_age_70_not_eligible_baseline(self):
+        """70-year-old should NOT be eligible for EITC under baseline (max age 64)."""
+        situation = build_single_person_situation(age=70, employment_income=10000)
+        sim = Simulation(situation=situation)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        assert eitc == 0
+
+    def test_eitc_phase_in_rate_reform(self):
+        """Reform should use 15.3% phase-in rate (doubled from 7.65%)."""
+        # At $5,000 income: 15.3% * $5,000 = $765
+        situation = build_single_person_situation(age=30, employment_income=5000)
+        reform = create_reform(year=YEAR)
+        sim = Simulation(situation=situation, reform=reform)
+        eitc = sim.calculate("eitc", period=YEAR)[0]
+        expected = 5000 * 0.153
+        assert eitc == pytest.approx(expected, abs=10)
+
+
+class TestOverallImpact:
+    """Test overall tax impact of the reform."""
+
+    def test_single_filer_pays_less_tax(self):
+        """Single filer at $50k should pay less tax under reform."""
+        situation = build_single_person_situation(age=30, employment_income=50000)
+
+        baseline = Simulation(situation=situation)
+        baseline_tax = baseline.calculate("income_tax", period=YEAR)[0]
+
+        reform = create_reform(year=YEAR)
+        reformed = Simulation(situation=situation, reform=reform)
+        reform_tax = reformed.calculate("income_tax", period=YEAR)[0]
+
+        # Reform should reduce taxes
+        assert reform_tax < baseline_tax
+
+    def test_single_parent_net_income_increases(self):
+        """Single parent should have higher net income under reform."""
+        situation = build_single_parent_situation(
+            parent_age=30, child_age=5, employment_income=40000
+        )
+
+        baseline = Simulation(situation=situation)
+        baseline_net = baseline.calculate("household_net_income", period=YEAR)[0]
+
+        reform = create_reform(year=YEAR)
+        reformed = Simulation(situation=situation, reform=reform)
+        reform_net = reformed.calculate("household_net_income", period=YEAR)[0]
+
+        # Reform should increase net income
+        assert reform_net > baseline_net


### PR DESCRIPTION
## Summary
- Add tabbed taxable income chart with Single/Head of Household/Married filing jointly tabs
- Use WATCA color scheme for consistency across PolicyEngine tools
- Fix Y-axis domain to [0, 100k] with consistent ticks across all filing status tabs
- Update CTC chart X-axis ticks to 0, 100k, 200k, 300k
- Reorder charts: taxable income before CTC
- Remove redundant CTC comparison table and taxable income footnote
- Update EITC table title to include "(2026)"
- Add comprehensive pytest tests for reform behavior (standard deduction, CTC, EITC)

## Test plan
- [ ] Verify taxable income chart tabs work correctly for all three filing statuses
- [ ] Verify Y-axis is consistent across all tabs
- [ ] Verify CTC chart displays correctly with new tick marks
- [ ] Run `pytest tests/test_reforms.py -v` to verify reform tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)