### PR TITLE
Frontend edits: dependent age labels and CTC footnote

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -206,7 +206,9 @@ function HouseholdImpactTab() {
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-primary focus:border-transparent"
             />
             {dependentAges.length > 0 && (
-              <div className="grid grid-cols-3 gap-1 mt-2">
+              <div className="mt-2">
+                <label className="block text-xs font-medium text-gray-500 mb-1">Age(s)</label>
+                <div className="grid grid-cols-3 gap-1">
                 {dependentAges.map((age, i) => (
                   <input
                     key={i}
@@ -223,6 +225,7 @@ function HouseholdImpactTab() {
                     placeholder={`Age ${i + 1}`}
                   />
                 ))}
+                </div>
               </div>
             )}
           </div>
@@ -244,7 +247,7 @@ function HouseholdImpactTab() {
             </div>
             {expectingBaby && (
               <p className="text-xs text-gray-500 mt-1">
-                Adds a $2,400 baby bonus on top of the under-6 CTC
+                Adds a $2,400 baby bonus on top of the under-6 CTC ($6,360 total)
               </p>
             )}
           </div>

--- a/frontend/components/PolicyOverview.tsx
+++ b/frontend/components/PolicyOverview.tsx
@@ -307,7 +307,7 @@ export default function PolicyOverview() {
           </ResponsiveContainer>
         </div>
         <p className="text-xs text-gray-500 mt-2">
-          Children under the age of 1 would receive a combined credit of $6,360 as they are entitled to the $2,400 baby bonus for their birth month and $360/month for the remaining 11 months ($3,960).
+          Children under the age of 1 would receive a combined credit of $6,360 as they are entitled to the $2,400 baby bonus for their birth month and $360/month for the remaining 11 months ($3,960). The AFA phases down the CTC from its maximum amounts per child to $2,000, beginning at $112,500 for head of household filers. The AFA also raises the head of household threshold for the normal CTC phase-out from $200,000 to $300,000.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- Add "Age(s)" label above dependent age inputs in household calculator
- Update baby bonus note to show total ($6,360)
- Add AFA CTC phase-out details to CTC chart footnote (phases down to $2,000 starting at $112,500 for HoH, raises HoH threshold from $200k to $300k)

Closes #8

## Test plan
- [ ] Verify "Age(s)" label appears above dependent age inputs when dependents > 0
- [ ] Verify baby bonus note shows ($6,360 total)
- [ ] Verify CTC chart footnote includes phase-out information

🤖 Generated with [Claude Code](https://claude.com/claude-code)