### PR TITLE
Add analysis scope footnote to overview page

### DIFF
--- a/frontend/components/PolicyOverview.tsx
+++ b/frontend/components/PolicyOverview.tsx
@@ -137,6 +137,9 @@ export default function PolicyOverview() {
           </a>
           .
         </p>
+        <p className="text-xs text-gray-500 mt-2">
+          This analysis is limited to the three provisions listed above. As more details of the proposal are made public, we may update this analysis.
+        </p>
       </div>
 
       {/* Bar chart comparison */}


### PR DESCRIPTION
## Summary
- Add footnote below provision cards clarifying that the analysis is limited to three provisions
- Notes that the analysis may be updated as more details become available

Closes #11

## Test plan
- [ ] Verify footnote appears below the provision cards on the overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)