### PR TITLE
Set default basePath to /us/keep-your-pay-act

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,5 @@
 /** @type {import('next').NextConfig} */
-const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "/us/keep-your-pay-act";
 
 const nextConfig = {
   ...(basePath ? { basePath } : {}),


### PR DESCRIPTION
## Summary
- Change default basePath from empty string to `/us/keep-your-pay-act` to match the Vercel rewrite in policyengine-app-v2

CSS/JS assets are currently broken on policyengine.org/us/keep-your-pay-act because the basePath doesn't match the rewrite URL.

## Test plan
- [ ] Verify policyengine.org/us/keep-your-pay-act loads with styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)
