### PR TITLE
Fix SEO: www canonical, og:image, JSON-LD

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({
   display: 'swap',
 });
 
-const SITE_URL = 'https://policyengine.org/us/keep-your-pay-act';
+const SITE_URL = 'https://www.policyengine.org/us/keep-your-pay-act';
 
 export const metadata: Metadata = {
   title: 'Keep Your Pay Act Calculator',
@@ -30,12 +30,22 @@ export const metadata: Metadata = {
     siteName: 'PolicyEngine',
     type: 'website',
     locale: 'en_US',
+    images: [
+      {
+        url: 'https://www.policyengine.org/assets/posts/keep-your-pay-act-calculator.png',
+        width: 1200,
+        height: 630,
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Keep Your Pay Act Calculator',
     description:
       'Calculate your personal and national tax impact under the Keep Your Pay Act.',
+    images: [
+      'https://www.policyengine.org/assets/posts/keep-your-pay-act-calculator.png',
+    ],
   },
   other: {
     'theme-color': '#2C7A7B',
@@ -57,6 +67,27 @@ export default function RootLayout({
   return (
     <html lang="en" className={inter.className}>
       <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebApplication',
+              name: 'Keep Your Pay Act Calculator',
+              description:
+                "Calculate your personal and national tax impact under the Keep Your Pay Act.",
+              url: SITE_URL,
+              applicationCategory: 'FinanceApplication',
+              operatingSystem: 'Any',
+              offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+              provider: {
+                '@type': 'Organization',
+                name: 'PolicyEngine',
+                url: 'https://www.policyengine.org',
+              },
+            }),
+          }}
+        />
         <Script
           src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
           strategy="afterInteractive"

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -6,6 +6,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: '*',
       allow: '/',
     },
-    sitemap: 'https://policyengine.org/us/keep-your-pay-act/sitemap.xml',
+    sitemap: 'https://www.policyengine.org/us/keep-your-pay-act/sitemap.xml',
   };
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -3,8 +3,8 @@ import type { MetadataRoute } from 'next';
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: 'https://policyengine.org/us/keep-your-pay-act',
-      lastModified: new Date(),
+      url: 'https://www.policyengine.org/us/keep-your-pay-act',
+      lastModified: '2026-03-10',
       changeFrequency: 'weekly',
       priority: 1,
     },


### PR DESCRIPTION
## Summary

- **Fix canonical URL mismatch**: `policyengine.org` 307-redirects to `www.policyengine.org`, but canonical/sitemap/robots all pointed to the non-www URL. Google sees a canonical that redirects away from itself, preventing indexing.
- **Add `og:image` and `twitter:image`**: Social shares (Twitter, LinkedIn, Slack) had no preview image. Uses the existing `keep-your-pay-act-calculator.png` asset hosted on policyengine.org.
- **Add `WebApplication` JSON-LD**: Enables rich snippet eligibility in Google search results (calculator tool, free, FinanceApplication category).
- **Fix sitemap `lastModified`**: Was `new Date()` (changes every request, diluting signal to crawlers), now a fixed date.

## Context

The page is not appearing in Google search results despite being in the policyengine.org sitemap. Investigation found two root causes:

1. **The app-v2 middleware intercepts Googlebot** and serves a 3-line HTML stub instead of this app full SSR page (fix in companion PR: PolicyEngine/policyengine-app-v2#832)
2. **All canonical/OG URLs point to `policyengine.org` (no www)** which 307-redirects to `www.policyengine.org` — Google sees a canonical that redirects away from itself

This PR fixes issue 2 and also adds the og:image and JSON-LD that the middleware was previously providing via its stub. Once the middleware stops intercepting (PR 832), this app needs to provide its own complete meta tags.

## Risk assessment

| Concern | Risk | Detail |
|---------|------|--------|
| **Analytics** | **None** | GA setup is unchanged. Only meta tags and structured data are modified. |
| **Deployment** | **Safe** | No config changes, no env var changes, no build changes. Only metadata in layout.tsx, sitemap.ts, and robots.ts. |
| **Social share previews** | **Improved** | Previously had no og:image — social shares showed no preview image. Now they will. |
| **Existing SEO** | **None** | Page is not currently indexed, so there is nothing to regress. |

## Changes

### `frontend/app/layout.tsx`
- `SITE_URL`: `policyengine.org` → `www.policyengine.org`
- Added `openGraph.images` with 1200x630 image
- Added `twitter.images`
- Added `<script type="application/ld+json">` with WebApplication schema

### `frontend/app/sitemap.ts`
- URL: `policyengine.org` → `www.policyengine.org`
- `lastModified`: `new Date()` → `2026-03-10` (fixed date)

### `frontend/app/robots.ts`
- Sitemap URL: `policyengine.org` → `www.policyengine.org`

## Depends on

- PolicyEngine/policyengine-app-v2#832 (middleware bypass so Googlebot sees this SSR page instead of the stub)

## Test plan

- [ ] Verify `curl -s https://www.policyengine.org/us/keep-your-pay-act | grep canonical` shows `www.policyengine.org`
- [ ] Verify `curl -s https://www.policyengine.org/us/keep-your-pay-act | grep og:image` shows the image URL
- [ ] Verify og:image appears in social share preview (use https://cards-dev.twitter.com/validator or opengraph.xyz)
- [ ] After both PRs deploy, request indexing in Google Search Console

Generated with [Claude Code](https://claude.com/claude-code)