### PR TITLE
Align PolicyEngine shell navigation

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -13,8 +13,8 @@ const inter = Inter({
   display: 'swap',
 });
 
-const SITE_URL = 'https://policyengine.org/us/keep-your-pay-act';
-const OG_IMAGE = 'https://policyengine.org/assets/logos/policyengine/og-logo.png';
+const SITE_URL = 'https://www.policyengine.org/us/keep-your-pay-act';
+const OG_IMAGE = 'https://www.policyengine.org/assets/logos/policyengine/og-logo.png';
 
 export const metadata: Metadata = {
   title: {
@@ -103,8 +103,8 @@ const jsonLd = {
   provider: {
     '@type': 'Organization',
     name: 'PolicyEngine',
-    url: 'https://policyengine.org',
-    logo: 'https://policyengine.org/assets/logos/policyengine/og-logo.png',
+    url: 'https://www.policyengine.org',
+    logo: 'https://www.policyengine.org/assets/logos/policyengine/og-logo.png',
     sameAs: [
       'https://twitter.com/ThePolicyEngine',
       'https://www.facebook.com/PolicyEngine',

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/api/', '/_next/'],
       },
     ],
-    sitemap: 'https://policyengine.org/us/keep-your-pay-act/sitemap.xml',
-    host: 'https://policyengine.org',
+    sitemap: 'https://www.policyengine.org/us/keep-your-pay-act/sitemap.xml',
+    host: 'https://www.policyengine.org',
   };
 }

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -3,14 +3,14 @@ import type { MetadataRoute } from 'next';
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: 'https://policyengine.org/us/keep-your-pay-act',
-      lastModified: new Date(),
+      url: 'https://www.policyengine.org/us/keep-your-pay-act',
+      lastModified: '2026-05-10',
       changeFrequency: 'weekly',
       priority: 1,
     },
     {
-      url: 'https://policyengine.org/us/keep-your-pay-act/amt-chart',
-      lastModified: new Date(),
+      url: 'https://www.policyengine.org/us/keep-your-pay-act/amt-chart',
+      lastModified: '2026-05-10',
       changeFrequency: 'monthly',
       priority: 0.7,
     },

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 /**
  * Header matching policyengine-app-v2 exactly.
@@ -22,12 +22,15 @@ const FONT = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sa
 const NAV_ITEMS = [
   { label: 'Research', href: 'https://policyengine.org/us/research' },
   { label: 'Model', href: 'https://policyengine.org/us/model' },
+  { label: 'API', href: 'https://policyengine.org/us/api' },
+  { label: 'Python', href: 'https://policyengine.org/us/python' },
   {
     label: 'About',
     hasDropdown: true,
     items: [
       { label: 'Team', href: 'https://policyengine.org/us/team' },
       { label: 'Supporters', href: 'https://policyengine.org/us/supporters' },
+      { label: 'Citations', href: 'https://policyengine.org/us/citations' },
     ],
   },
   { label: 'Donate', href: 'https://policyengine.org/us/donate' },

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,3 +1,8 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 // Use empty string for local dev (NEXT_PUBLIC_BASE_PATH=""), otherwise default to production path
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH !== undefined
   ? process.env.NEXT_PUBLIC_BASE_PATH
@@ -10,6 +15,9 @@ const nextConfig = {
   compress: true,
   images: {
     formats: ['image/avif', 'image/webp'],
+  },
+  turbopack: {
+    root: path.join(__dirname, ".."),
   },
   async headers() {
     return [


### PR DESCRIPTION
## Summary
- add missing API/Python/Citations entries to the PE shell nav
- set Turbopack root so frontend imports of the repo-root reform JSON build under Next 16
- fold in stale SEO cleanup from #31: www canonical URLs and stable sitemap timestamps

## Verification
- bun run build
- bun run lint (warnings only, pre-existing image/any warnings)