### PR TITLE
Restore pre-codex nav (drop API/Python/Citations entries)

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -22,15 +22,12 @@ const FONT = "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sa
 const NAV_ITEMS = [
   { label: 'Research', href: 'https://policyengine.org/us/research' },
   { label: 'Model', href: 'https://policyengine.org/us/model' },
-  { label: 'API', href: 'https://policyengine.org/us/api' },
-  { label: 'Python', href: 'https://policyengine.org/us/python' },
   {
     label: 'About',
     hasDropdown: true,
     items: [
       { label: 'Team', href: 'https://policyengine.org/us/team' },
       { label: 'Supporters', href: 'https://policyengine.org/us/supporters' },
-      { label: 'Citations', href: 'https://policyengine.org/us/citations' },
     ],
   },
   { label: 'Donate', href: 'https://policyengine.org/us/donate' },


### PR DESCRIPTION
## Summary
Codex's #37 (\"Align PolicyEngine shell navigation\") added three new nav entries to the local `Header.tsx`:
- top-level `API` → `policyengine.org/us/api`
- top-level `Python` → `policyengine.org/us/python`
- `About` sub-item `Citations` → `policyengine.org/us/citations`

Those weren't part of the pre-codex nav, which had Research / Model / About (Team, Supporters) / Donate. Reverting just the `NAV_ITEMS` additions restores the original navigation.

## Kept from #37
- `SITE_URL`/`OG_IMAGE` canonical URL changes (`policyengine.org` → `www.policyengine.org`)
- Turbopack `root` config in `next.config.mjs`
- robots / sitemap cleanups

## Verification
- `bun run build` — clean