### PR TITLE
Move PolicyEngine version note to results footnote

### DIFF
--- a/frontend/components/AggregateImpact.tsx
+++ b/frontend/components/AggregateImpact.tsx
@@ -466,6 +466,16 @@ export default function AggregateImpact({ triggered }: Props) {
 
       <p className="text-sm text-gray-500 bg-gray-50 rounded-lg px-4 py-3 border border-gray-200">
         These estimates are static: they do not capture behavioral responses such as changes in labor supply, tax avoidance, or migration.
+        {' '}Calculations use{' '}
+        <a
+          href="https://github.com/PolicyEngine/policyengine.py"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-primary-600 hover:underline"
+        >
+          policyengine
+        </a>
+        {' '}v4.4.4.
       </p>
     </div>
   );

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -154,18 +154,6 @@ export default function Footer() {
               <p style={{ fontSize: '12px', color: '#fff', margin: 0, fontFamily: FONT }}>
                 &copy; {new Date().getFullYear()} PolicyEngine. All rights reserved.
               </p>
-              <p style={{ fontSize: '11px', color: '#fff', opacity: 0.8, margin: 0, fontFamily: FONT }}>
-                Calculations powered by{' '}
-                <a
-                  href="https://github.com/PolicyEngine/policyengine.py"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: '#fff', textDecoration: 'underline' }}
-                >
-                  policyengine
-                </a>
-                {' '}v4.4.4
-              </p>
             </div>
           </div>
 

--- a/tests/test_results_provenance.py
+++ b/tests/test_results_provenance.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_policyengine_footer_has_no_model_provenance():
+    footer = (ROOT / "frontend/components/Footer.tsx").read_text()
+
+    assert "policyengine.py" not in footer
+    assert "v4.4.4" not in footer
+
+
+def test_results_footnote_shows_model_provenance():
+    aggregate = (ROOT / "frontend/components/AggregateImpact.tsx").read_text()
+
+    assert "These estimates are static" in aggregate
+    assert "policyengine.py" in aggregate
+    assert "v4.4.4" in aggregate


### PR DESCRIPTION
## Summary\n- remove the model-version note from the shared PolicyEngine footer\n- add policyengine v4.4.4 to the KYPA National Impact results footnote\n- add a regression test for this placement\n\n## Verification\n- uv run --with pytest python -m pytest tests/test_results_provenance.py -q\n- npm run lint (passes with existing warnings)\n- npm run build