### PR TITLE
Wrap layout with @policyengine/ui-kit PolicyEngineShell

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,3 +1,6 @@
+import { PolicyEngineShell } from "@policyengine/ui-kit/layout";
+import "@policyengine/ui-kit/styles.css";
+
 import Script from 'next/script';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
@@ -186,9 +189,11 @@ export default function RootLayout({
         </Script>
       </head>
       <body>
+        <PolicyEngineShell country="us">
         <Providers>
           {children}
         </Providers>
+              </PolicyEngineShell>
       </body>
     </html>
   );

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "keep-your-pay-act-calculator",
       "dependencies": {
-        "@policyengine/ui-kit": "^0.9.0",
+        "@policyengine/ui-kit": "^0.12.0",
         "@tanstack/react-query": "^5.17.9",
         "axios": "^1.6.5",
         "next": "^16.2.6",
@@ -195,7 +195,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.9.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-oPqMSr+qSdY/63xZ8b7dO3q5Bhceg5UQCiZ/m4tOqcywviQk5VO8FKzkUR8pzmFIv8Q4TB3b2OB0ZKfo6UzHQw=="],
+    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.12.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-Psz6j9ykKjGzrvEHR2Evv1EbOS/H7eBM5iydd7GfxCD2eQgu6uMWw2sLZXNFfmhKKDxevheynnaATcKJOw5QGQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@policyengine/ui-kit": "^0.9.0",
+    "@policyengine/ui-kit": "^0.12.0",
     "@tanstack/react-query": "^5.17.9",
     "axios": "^1.6.5",
     "next": "^16.2.6",


### PR DESCRIPTION
Wraps the app's root layout with `<PolicyEngineShell country="us">` from `@policyengine/ui-kit ^0.12.0` so policyengine.org/us/* renders the PolicyEngine site header + footer around this tool. Adds the ui-kit dependency. Layout edit is mechanical and idempotent.