### PR TITLE
Drop in-app Header duplicate (PolicyEngineShell provides it)

### DIFF
--- a/frontend/app/(shell)/layout.tsx
+++ b/frontend/app/(shell)/layout.tsx
@@ -8,7 +8,6 @@ export default function ShellLayout({
 }) {
   return (
     <>
-      <Header />
       {children}
       <Footer />
     </>

--- a/frontend/app/amt-chart/layout.tsx
+++ b/frontend/app/amt-chart/layout.tsx
@@ -8,7 +8,6 @@ export default function AmtChartLayout({
 }) {
   return (
     <>
-      <Header />
       {children}
       <Footer />
     </>


### PR DESCRIPTION
PolicyEngineShell renders the PE site header. The in-app `<Header />` stacked a second nav bar on top.